### PR TITLE
Fixing hardcoded birds bug

### DIFF
--- a/Assets/Scenes/SplashScreenScene.unity
+++ b/Assets/Scenes/SplashScreenScene.unity
@@ -3348,9 +3348,7 @@ MonoBehaviour:
     spawnRadius: 0
     birdImage: {fileID: 0}
     location: {x: 0, y: 0, z: 0}
-  userCapturedBirds:
-  - {fileID: 5111982898910581401, guid: 3c12fa5733036f249acbe233dc6b748c, type: 3}
-  - {fileID: 5111982898910581401, guid: deef19314a3d9be4c92376beb142bd70, type: 3}
+  userCapturedBirds: []
   userGalleryPics: []
 --- !u!114 &956248233
 MonoBehaviour:

--- a/Assets/Scripts/Data/UserAvidexBird.cs
+++ b/Assets/Scripts/Data/UserAvidexBird.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class UserAvidexBird : MonoBehaviour
+public class UserAvidexBird
 {
     public BirdData birdData;
     public List<BirdCaptureData> captureData;


### PR DESCRIPTION
The user had two hardcoded birds before. If these birds got removed then the birds were not being populated in the Avidex correctly (profile picture wasn't shown and data wasn't being transferred). The fix was making UserAvidexBird a regular C# object and not a MonoBehavior. Apparently MonoBehavior objects are scene dependent and can get destroyed when changing scenes which was causing it to be come null. 